### PR TITLE
Fixes benchmark / stress test numbers

### DIFF
--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -29,7 +29,7 @@ where
     let end = time::Instant::now();
 
     let duration = end.duration_since(start);
-    let runtime_secs = duration.as_secs() + (duration.subsec_nanos() as f64 / 1_000_000_000.0);
+    let runtime_secs = duration.as_secs() + (duration.subsec_nanos() as f64 / 1_000_000_000.0) as u64;
     (res, runtime_secs)
 }
 

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -28,8 +28,8 @@ where
     let res = f();
     let end = time::Instant::now();
 
-    let runtime_nanos = end.duration_since(start).subsec_nanos();
-    let runtime_secs = runtime_nanos as f64 / 1_000_000_000.0;
+    let duration = end.duration_since(start);
+    let runtime_secs = duration.as_secs() + (duration.subsec_nanos() as f64 / 1_000_000_000.0);
     (res, runtime_secs)
 }
 


### PR DESCRIPTION
You'll notice that [here](https://github.com/seenaburns/raytracer/blob/master/src/bench.rs#L32), they're using `num_nanoseconds`, which is different than you have it here.

[subsec_nanos](https://doc.rust-lang.org/std/time/struct.Duration.html#method.subsec_nanos) only returns, as you might guess, sub-seconds (only the fractional part).

This made me think that image captures were happening 100s of times faster than they actually were.