### PR TITLE
Remove "debug" flag, Use tracing instead of println!, Use tracing-subscriber for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,14 @@ libc = "0.2"
 parking_lot = "0.10"
 scopeguard = "1.0"
 futures = "0.3"
+tracing = "0.1.37"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
+tracing-subscriber = "0.3.16"
 
 [features]
 default = []
-
-# Enable this feature to enable some print statements for debugging.
-debug = []
 
 [package.metadata.docs.rs]
 default-target = "armv7-unknown-linux-gnueabihf"

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ rascam = "0.0.2"
 
 Check out the [SimpleCamera example](https://github.com/pedrosland/rascam/blob/master/examples/simple.rs) to get started quickly.
 
-If things are crashing or producing unexpected results there is a feature which enables some print statements which may help to debug an issue:
+This crate uses [tracing](https://crates.io/crates/tracing) to produce logging events. 
+If things are crashing or producing unexpected results, you can print the logs by adding the [tracing-subscriber](https://crates.io/crates/tracing-subscriber) crate to your project.
+Enable the logging by putting `tracing_subscriber::fmt::init();` at the top of your `main()` function. Set the `RUST_LOG` environment variable to `DEBUG`.
+For example, this can be done by calling cargo like this: `$ RUST_LOG=DEBUG cargo run`.
 
 ```toml
 [dependencies]
-rascam = { version = "0.0.1", features = ["debug"] }
+rascam = { version = "0.0.1" }
 ```
 
 ## License

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -3,22 +3,26 @@ use std::time::Duration;
 use tokio::fs::File;
 use tokio::prelude::*;
 use tokio::time::delay_for;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() {
+    // Set up logging to stdout
+    tracing_subscriber::fmt::init();
+
     let info = info().unwrap();
     if info.cameras.len() < 1 {
-        println!("Found 0 cameras. Exiting");
+        error!("Found 0 cameras. Exiting");
         // note that this doesn't run destructors
         ::std::process::exit(1);
     }
-    println!("{}", info);
+    info!("{}", info);
 
     let result = simple_async(&info.cameras[0]).await;
     match result {
-        Ok(_) => println!("Saved image as image.jpg"),
+        Ok(_) => info!("Saved image as image.jpg"),
         Err(err) => {
-            println!("error: {}", err);
+            error!("error: {}", err);
             ::std::process::exit(1);
         }
     }

--- a/examples/serious.rs
+++ b/examples/serious.rs
@@ -2,30 +2,34 @@ use rascam::*;
 use std::fs::File;
 use std::io::Write;
 use std::{thread, time};
+use tracing::{error, info};
 
 fn main() {
+    // Set up logging to stdout
+    tracing_subscriber::fmt::init();
+
     let info = info().unwrap();
     if info.cameras.len() < 1 {
-        println!("Found 0 cameras. Exiting");
+        error!("Found 0 cameras. Exiting");
         // note that this doesn't run destructors
         ::std::process::exit(1);
     }
-    println!("{}", info);
+    info!("{}", info);
 
     serious(&info.cameras[0]);
 }
 
 fn serious(info: &CameraInfo) {
     let mut camera = SeriousCamera::new().unwrap();
-    println!("camera created");
+    info!("camera created");
     camera.set_camera_num(0).unwrap();
-    println!("camera number set");
+    info!("camera number set");
     camera.create_encoder().unwrap();
-    println!("encoder created");
+    info!("encoder created");
     camera.enable_control_port(true).unwrap();
-    println!("camera control port enabled");
+    info!("camera control port enabled");
     camera.set_camera_params(info).unwrap();
-    println!("camera params set");
+    info!("camera params set");
 
     let settings = CameraSettings {
         encoding: MMAL_ENCODING_RGB24,
@@ -37,20 +41,20 @@ fn serious(info: &CameraInfo) {
     };
 
     camera.set_camera_format(&settings).unwrap();
-    println!("set camera format");
+    info!("set camera format");
     camera.enable().unwrap();
-    println!("camera enabled");
+    info!("camera enabled");
     camera.create_pool().unwrap();
-    println!("pool created");
+    info!("pool created");
 
     camera.create_preview().unwrap();
-    println!("preview created");
+    info!("preview created");
     camera.connect_preview().unwrap();
-    println!("preview connected");
+    info!("preview connected");
     camera.enable_preview().unwrap();
-    println!("preview enabled");
+    info!("preview enabled");
 
-    println!("taking photo");
+    info!("taking photo");
 
     let sleep_duration = time::Duration::from_millis(2000);
     thread::sleep(sleep_duration);
@@ -64,8 +68,8 @@ fn serious(info: &CameraInfo) {
         .write_all(&buffer.get_bytes())
         .unwrap();
 
-    println!("Raw rgb bytes written to image.rgb");
-    println!("Try: convert -size 96x96 -depth 8 -colorspace RGB rgb:image.rgb image.png");
+    info!("Raw rgb bytes written to image.rgb");
+    info!("Try: convert -size 96x96 -depth 8 -colorspace RGB rgb:image.rgb image.png");
     // If imagemagick gives something like:
     //   convert-im6.q16: unexpected end-of-file `image.rgb': No such file or directory @ error/rgb.c/ReadRGBImage/239.
     // There is probably padding in the image. Check the width.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,15 +2,19 @@ use rascam::*;
 use std::fs::File;
 use std::io::Write;
 use std::{thread, time};
+use tracing::{error, info};
 
 fn main() {
+    // Set up logging to stdout
+    tracing_subscriber::fmt::init();
+
     let info = info().unwrap();
     if info.cameras.len() < 1 {
-        println!("Found 0 cameras. Exiting");
+        error!("Found 0 cameras. Exiting");
         // note that this doesn't run destructors
         ::std::process::exit(1);
     }
-    println!("{}", info);
+    info!("{}", info);
 
     simple_sync(&info.cameras[0]);
 }
@@ -25,5 +29,5 @@ fn simple_sync(info: &CameraInfo) {
     let b = camera.take_one().unwrap();
     File::create("image.jpg").unwrap().write_all(&b).unwrap();
 
-    println!("Saved image as image.jpg");
+    info!("Saved image as image.jpg");
 }

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -1,16 +1,20 @@
 use rascam::*;
 use std::{thread, time};
+use tracing::{error, info};
 
 // Make sure to run with --release
 
 fn main() {
+    // Set up logging to stdout
+    tracing_subscriber::fmt::init();
+
     let info = info().unwrap();
     if info.cameras.len() < 1 {
-        println!("Found 0 cameras. Exiting");
+        error!("Found 0 cameras. Exiting");
         // note that this doesn't run destructors
         ::std::process::exit(1);
     }
-    println!("{}", info);
+    info!("{}", info);
 
     bench_jpegs_per_sec(10);
 }
@@ -49,13 +53,13 @@ fn bench_jpegs_per_sec(n: i32) {
         let images = 30;
         let (_, runtime) = time(|| bench_jpegs(images, &mut b));
         let images_per_sec = images as f64 / runtime;
-        println!(
+        info!(
             "{} images in {} sec, {:.2} images/sec",
             images, runtime, images_per_sec
         );
         runs.push(images_per_sec);
     }
-    println!(
+    info!(
         "Avg: {:.2} images/sec from {} runs",
         runs.iter().sum::<f64>() / (runs.len() as f64),
         runs.len()


### PR DESCRIPTION
Hi, this PR removes the debug flag in favor of using an actual logging framework. 
`tracing` is the state-of-the-art logging framework.
I replaced all the `println!` debug statements with `tracing::debug!`. Actually I used just `debug!` so it could be easier to switch to a different logging frame work in the future without changing all references to `debug!`. For example the former best logging framework `log` uses the same names for the macros, making migration easy. 

For the examples, I added a dev-dependency `tracing-subscriber`. This crate is needed, because `tracing` doesn't actually print anything. `tracing-subscriber` consumes the events produced by `tracing`. FYI there are other consumers.

I also removed the `debug` flag, since the debug level can now easily be controlled by setting env variables. Debug logs can be turned off on a per crate basis by the users. 

I updated the `README.md` accordingly.